### PR TITLE
Create C5 spline interpolation for angular orientations + Enable spline velocity and acceleration maximum bounding

### DIFF
--- a/src/planning/planning/utils/path_3d_rotation.py
+++ b/src/planning/planning/utils/path_3d_rotation.py
@@ -1,18 +1,29 @@
+import matplotlib
+matplotlib.use('Agg')
+
 import numpy as np
 from scipy.interpolate import make_interp_spline
-from scipy.spatial.transform import Rotation, RotationSpline
+from scipy.spatial.transform import Rotation#, RotationSpline
+
 import matplotlib.pyplot as plt
 from matplotlib.animation import FuncAnimation
 from mpl_toolkits.mplot3d import Axes3D
+from scipy.interpolate import CubicSpline
 
 # Example points (x, y)
-x = np.random.rand(5)
-y = np.random.rand(5)
-z = np.random.rand(5)
-orientations = Rotation.random(5).as_euler("xyz", degrees=True)
+x = np.random.rand(2)
+y = np.random.rand(2)
+z = np.random.rand(2)
+# orientations = Rotation.random(5).as_euler("xyz", degrees=True)
 x = np.concatenate((x, [x[0]]))
 y = np.concatenate((y, [y[0]]))
 z = np.concatenate((z, [z[0]]))
+# orientations = np.concatenate((orientations, [orientations[0]]))
+
+arr = np.linspace(-180, 180, 1)
+# orientations = np.array([[-179.99, -179.99, -179.99], [179.99, 179.99, 179.99]])
+# orientations = np.array([[-1, -1, -1], [1, 1, 1]])
+# orientations = np.array([[-149.99, -149.99, -149.99], [149.99, 149.99, 149.99]])
 orientations = np.concatenate((orientations, [orientations[0]]))
 
 # Parameter t (can be the distance between the points or just range of integers)
@@ -31,25 +42,81 @@ splines = [
 # Define a finer grid of t values for evaluation
 t_fine = np.linspace(0, 1, 100)
 
-orientation_spline = RotationSpline(
-    t, Rotation.from_euler("xyz", orientations, degrees=True)
-)
+class RotationSpline:
+    def __init__(self, t, quaternions):
+
+        assert len(t) == len(quaternions)
+        
+        self.t = t
+        self.quaternions = quaternions
+
+        self.rotations = Rotation.from_quat(quaternions)
+        self.rotvecs = self.rotations.as_rotvec()
+
+        print(self.rotvecs)
+
+        self.spline_x = make_interp_spline(t, self.rotvecs[:, 0], k=5, bc_type=([(1, 0.0), (2, 0.0)], [(1, 0.0), (2, 0.0)]))
+        self.spline_y = make_interp_spline(t, self.rotvecs[:, 1], k=5, bc_type=([(1, 0.0), (2, 0.0)], [(1, 0.0), (2, 0.0)]))
+        self.spline_z = make_interp_spline(t, self.rotvecs[:, 2], k=5, bc_type=([(1, 0.0), (2, 0.0)], [(1, 0.0), (2, 0.0)]))
+
+
+    def __call__(self, t_single):
+        t_array = np.array([t_single])
+        quaternions_fine = self.evaluate(t_array)
+        return quaternions_fine[0]
+
+    def evaluate(self, t_fine):
+        rotvecs_fine = np.vstack((
+            self.spline_x(t_fine),
+            self.spline_y(t_fine),
+            self.spline_z(t_fine)
+        )).T
+        quaternions_fine = Rotation.from_rotvec(rotvecs_fine).as_quat()
+        return quaternions_fine
+
+    def as_euler(self, t_fine, order='xyz', degrees=False):
+        quaternions_fine = self.evaluate(t_fine)
+        rotations = Rotation.from_quat(quaternions_fine)
+        return rotations.as_euler(order, degrees=degrees)
+
+    def angular_velocity(self, t_fine):
+        angular_vel_x = self.spline_x(t_fine, 1)
+        angular_vel_y = self.spline_y(t_fine, 1)
+        angular_vel_z = self.spline_z(t_fine, 1)
+        return np.vstack((angular_vel_x, angular_vel_y, angular_vel_z)).T
+
+    def angular_acceleration(self, t_fine):
+        angular_acc_x = self.spline_x(t_fine, 2)
+        angular_acc_y = self.spline_y(t_fine, 2)
+        angular_acc_z = self.spline_z(t_fine, 2)
+        return np.vstack((angular_acc_x, angular_acc_y, angular_acc_z)).T
+    
+# orientation_spline = RotationSpline(
+#     t, Rotation.from_euler("xyz", orientations, degrees=True)
+# )
+
+quaternion_spline = RotationSpline(t, Rotation.from_euler("xyz", orientations, degrees=True).as_quat())
+
+# For angular velocities and accelerations:
+angular_velocities = quaternion_spline.angular_velocity(t_fine)
+angular_accelerations = quaternion_spline.angular_acceleration(t_fine)
 
 # Compute positions
 positions = [spline(t_fine) for spline in splines]
 x_fine, y_fine, z_fine = positions
-orientations = orientation_spline(t_fine).as_euler("xyz", degrees=True)
+# orientations = orientation_spline(t_fine).as_euler("xyz", degrees=True)
+orientations = quaternion_spline.as_euler(t_fine, order='xyz', degrees=True)
+
 
 # Compute velocities (first derivative)
 velocities = [spline(t_fine, 1) for spline in splines]
 v_x, v_y, v_z = velocities
-angular_velocities = orientation_spline(t_fine, 1)
-
+angular_velocities = quaternion_spline.angular_velocity(t_fine) #orientation_spline(t_fine, 1)
 
 # Compute accelerations (second derivative)
 accelerations = [spline(t_fine, 2) for spline in splines]
 a_x, a_y, a_z = accelerations
-angular_accelerations = orientation_spline(t_fine, 2)
+angular_accelerations = quaternion_spline.angular_acceleration(t_fine) #orientation_spline(t_fine, 2)
 
 # Plot the results
 plt.figure(figsize=(10, 8))
@@ -112,6 +179,8 @@ plt.ylabel("Angular Acceleration")
 plt.tight_layout()
 plt.show()
 
+plt.savefig("plot.png")
+
 
 # Setup the figure and 3D axis
 fig = plt.figure()
@@ -135,7 +204,7 @@ ax.legend()
 # Function to draw orientation (as a line or arrow)
 def draw_orientation(position, orientation):
     """Draws the orientation of the vehicle at a given position using the quaternion."""
-    direction = orientation.apply([1, 0, 0])
+    direction = Rotation.from_euler('xyz', orientation).apply([1, 0, 0])
     end_point = position + 0.2 * direction  # Scale for visualization
     return position, end_point
 
@@ -159,7 +228,7 @@ def animate(i):
 
     # Get the current quaternion and position
     position = np.array([x_fine[i], y_fine[i], z_fine[i]])
-    orientation = orientation_spline(t_fine[i])
+    orientation = Rotation.from_quat(quaternion_spline(t_fine[i])).as_euler('xyz')
 
     # Draw orientation line
     start, end = draw_orientation(position, orientation)
@@ -173,6 +242,8 @@ def animate(i):
 anim = FuncAnimation(
     fig, animate, init_func=init, frames=len(t_fine), interval=20, blit=True
 )
+
+anim.save('animation.mp4', writer='ffmpeg')
 
 # Show the animation
 plt.show()

--- a/src/planning/planning/utils/path_3d_rotation.py
+++ b/src/planning/planning/utils/path_3d_rotation.py
@@ -80,12 +80,18 @@ orientations = np.concatenate((orientations, [orientations[0]]))
 
 dim_vars = (x, y, z)
 
+max_velocity = 1
+max_acceleration = 1
+max_angular_velocity = 1
+max_angular_acceleration = 1
+
 # Fit splines to x y z as a function of t
 splines = []
 new_xs = [] # Spline intervals that ensure maxes are not exceeded
 for var in dim_vars:
     spline, new_x = make_interp_spline_with_constraints(
-        np.linspace(0, 1, len(x)), var, k=5, bc_type=([(1, 0.0), (2, 0.0)], [(1, 0.0), (2, 0.0)]), v_max=1, a_max=1
+        # Example, max absolute 1 m/s velocity and 1 m/s^2 acceleration 
+        np.linspace(0, 1, len(x)), var, k=5, bc_type=([(1, 0.0), (2, 0.0)], [(1, 0.0), (2, 0.0)]), v_max=max_velocity, a_max=max_acceleration
     )
     splines.append(spline)
     new_xs.append(new_x)
@@ -146,7 +152,7 @@ class RotationSpline:
         return np.vstack((angular_acc_x, angular_acc_y, angular_acc_z)).T
     
 # Fit splines to theta_x theta_y theta_z as a function of t
-quaternion_spline = RotationSpline(np.linspace(0, 1, len(x)), Rotation.from_euler("xyz", orientations, degrees=True).as_quat(), v_max=1, a_max=0.1)
+quaternion_spline = RotationSpline(np.linspace(0, 1, len(x)), Rotation.from_euler("xyz", orientations, degrees=True).as_quat(), v_max=max_angular_velocity, a_max=max_angular_acceleration)
 
 new_xs.extend([quaternion_spline.t_x, quaternion_spline.t_y, quaternion_spline.t_z])
 
@@ -157,7 +163,7 @@ for i in range(len(new_xs[0]) - 1):
 # Final update to splines with final_x
 splines = [
     make_interp_spline_with_constraints(
-        final_x, var, k=5, bc_type=([(1, 0.0), (2, 0.0)], [(1, 0.0), (2, 0.0)]), v_max=1, a_max=1
+        final_x, var, k=5, bc_type=([(1, 0.0), (2, 0.0)], [(1, 0.0), (2, 0.0)]), v_max=max_velocity, a_max=max_acceleration
     )[0] for var in dim_vars
 ]
 quaternion_spline.update_t(final_x)

--- a/src/planning/planning/utils/path_3d_rotation.py
+++ b/src/planning/planning/utils/path_3d_rotation.py
@@ -2,15 +2,17 @@ import matplotlib
 matplotlib.use('Agg')
 
 import numpy as np
-from scipy.interpolate import make_interp_spline, make_lsq_spline
-from scipy.spatial.transform import Rotation#, RotationSpline
+from scipy.interpolate import make_interp_spline
+from scipy.spatial.transform import Rotation
+from scipy.optimize import root_scalar
 
 import matplotlib.pyplot as plt
 from matplotlib.animation import FuncAnimation
-from mpl_toolkits.mplot3d import Axes3D
-from scipy.interpolate import CubicSpline
 
-from scipy.optimize import minimize_scalar, root_scalar
+import os
+
+if not os.path.exists("./out"):
+    os.mkdir("./out") # Make the output folder to store the visualization of path generation
 
 # Find the maximum value of a B-spline between t_start and t_end.
 def find_maximum_bspl(spline, t_start, t_end, num_points=1000):
@@ -178,7 +180,6 @@ angular_accelerations = quaternion_spline.angular_acceleration(t_fine)
 # Compute positions
 positions = [spline(t_fine) for spline in splines]
 x_fine, y_fine, z_fine = positions
-# orientations = orientation_spline(t_fine).as_euler("xyz", degrees=True)
 orientations = quaternion_spline.as_euler(t_fine, order='xyz', degrees=True)
 
 
@@ -253,7 +254,7 @@ plt.ylabel("Angular Acceleration")
 plt.tight_layout()
 plt.show()
 
-plt.savefig("plot.png")
+plt.savefig("out/plot.png")
 
 # Setup the figure and 3D axis
 fig = plt.figure()
@@ -316,7 +317,7 @@ anim = FuncAnimation(
     fig, animate, init_func=init, frames=len(t_fine), interval=20, blit=True
 )
 
-anim.save('animation.mp4', writer='ffmpeg')
+anim.save('out/animation.mp4', writer='ffmpeg')
 
 # Show the animation
 plt.show()

--- a/src/planning/planning/utils/path_3d_rotation_unbounded.py
+++ b/src/planning/planning/utils/path_3d_rotation_unbounded.py
@@ -10,64 +10,10 @@ from matplotlib.animation import FuncAnimation
 from mpl_toolkits.mplot3d import Axes3D
 from scipy.interpolate import CubicSpline
 
-from scipy.optimize import minimize_scalar, root_scalar
+def make_interp_spline_with_constraints(x, y, k=3, t=None, bc_type=None):
+    return make_interp_spline(x=x, y=y, k=k, t=t, bc_type=bc_type)
 
-# Find the maximum value of a B-spline between t_start and t_end.
-def find_maximum_bspl(spline, t_start, t_end, num_points=1000):
-    t_values = np.linspace(t_start, t_end, num_points)
-    spline_values = spline(t_values)
-    abs_spline_values = np.abs(spline_values)
-    max_value_index = np.argmax(abs_spline_values)
-    max_abs_value = abs_spline_values[max_value_index]
-    max_time = t_values[max_value_index]
-
-    derivative_spline = spline.derivative()
-
-    def derivative_root_finder(t):
-        return derivative_spline(t)
-
-    critical_points = []
-    for i in range(num_points - 1):
-        if t_values[i] < t_start or t_values[i + 1] > t_end:
-            continue
-        try:
-            root_result = root_scalar(
-                derivative_root_finder, bracket=[t_values[i], t_values[i + 1]], method='brentq'
-            )
-            if root_result.converged and t_start <= root_result.root <= t_end:
-                critical_points.append(root_result.root)
-        except ValueError:
-            pass
-
-    evaluation_points = [t_start, t_end] + critical_points
-    for t in evaluation_points:
-        spline_value = spline(t)
-        abs_spline_value = np.abs(spline_value)
-        if abs_spline_value > max_abs_value:
-            max_abs_value = abs_spline_value
-            max_time = t
-
-    return max_abs_value, max_time
-
-def make_interp_spline_with_constraints(x, y, k=3, t=None, bc_type=None, v_max=None, a_max=None):
-    spline_pos = make_interp_spline(x=x, y=y, k=k, t=t, bc_type=bc_type)
-
-    if v_max is None or a_max is None:
-        return spline_pos, x
-
-    spline_vel = spline_pos.derivative()
-    spline_acc = spline_vel.derivative()
-    factors = []
-    for i in range(len(x) - 1):
-        factors.append(max(find_maximum_bspl(spline_vel, x[i], x[i+1])[0]/v_max, (find_maximum_bspl(spline_acc, x[i], x[i+1])[0]/a_max)**0.5))
-    
-    x_new = [x[0]]
-    for i in range(len(factors)):
-        x_new.append(x_new[-1] + (x[i + 1] - x[i]) * factors[i])
-
-    return make_interp_spline(x=x, y=y, k=k, t=t, bc_type=bc_type), x_new
-
-# 5 example points (x, y, z, theta_x, theta_y, theta_z)
+# Example points (x, y)
 x = np.random.rand(5)
 y = np.random.rand(5)
 z = np.random.rand(5)
@@ -75,24 +21,34 @@ orientations = Rotation.random(5).as_euler("xyz", degrees=True)
 x = np.concatenate((x, [x[0]]))
 y = np.concatenate((y, [y[0]]))
 z = np.concatenate((z, [z[0]]))
+# orientations = np.concatenate((orientations, [orientations[0]]))
 
+# arr = np.linspace(-180, 180, 1)
+# orientations = np.array([[-179.99, -179.99, -179.99], [179.99, 179.99, 179.99]])
+# orientations = np.array([[-1, -1, -1], [1, 1, 1]])
+# orientations = np.array([[-149.99, -149.99, -149.99], [149.99, 149.99, 149.99]])
 orientations = np.concatenate((orientations, [orientations[0]]))
+
+t_end = 1
+
+# Parameter t (can be the distance between the points or just range of integers)
+t = np.linspace(0, t_end, len(x))
 
 dim_vars = (x, y, z)
 
-# Fit splines to x y z as a function of t
-splines = []
-new_xs = [] # Spline intervals that ensure maxes are not exceeded
-for var in dim_vars:
-    spline, new_x = make_interp_spline_with_constraints(
-        np.linspace(0, 1, len(x)), var, k=5, bc_type=([(1, 0.0), (2, 0.0)], [(1, 0.0), (2, 0.0)]), v_max=1, a_max=1
+# Fit cubic splines to x and y as a function of t
+splines = [
+    make_interp_spline_with_constraints(
+        t, var, k=5, bc_type=([(1, 0.0), (2, 0.0)], [(1, 0.0), (2, 0.0)])
     )
-    splines.append(spline)
-    new_xs.append(new_x)
+    for var in dim_vars
+]
 
-# Define modified rotation spline (interpolates on rot_vecs)
+# Define a finer grid of t values for evaluation
+t_fine = np.linspace(0, t_end, 100)
+
 class RotationSpline:
-    def __init__(self, t, quaternions, v_max=None, a_max=None):
+    def __init__(self, t, quaternions):
 
         assert len(t) == len(quaternions)
         
@@ -102,22 +58,17 @@ class RotationSpline:
         self.rotations = Rotation.from_quat(quaternions)
         self.rotvecs = self.rotations.as_rotvec()
 
-        self.v_max = v_max
-        self.a_max = a_max
+        print(self.rotvecs)
 
-        self.spline_x, self.t_x = make_interp_spline_with_constraints(t, self.rotvecs[:, 0], k=5, bc_type=([(1, 0.0), (2, 0.0)], [(1, 0.0), (2, 0.0)]), v_max=self.v_max, a_max=self.a_max)
-        self.spline_y, self.t_y = make_interp_spline_with_constraints(t, self.rotvecs[:, 1], k=5, bc_type=([(1, 0.0), (2, 0.0)], [(1, 0.0), (2, 0.0)]), v_max=self.v_max, a_max=self.a_max)
-        self.spline_z, self.t_z = make_interp_spline_with_constraints(t, self.rotvecs[:, 2], k=5, bc_type=([(1, 0.0), (2, 0.0)], [(1, 0.0), (2, 0.0)]), v_max=self.v_max, a_max=self.a_max)
+        self.spline_x = make_interp_spline(t, self.rotvecs[:, 0], k=5, bc_type=([(1, 0.0), (2, 0.0)], [(1, 0.0), (2, 0.0)]))
+        self.spline_y = make_interp_spline(t, self.rotvecs[:, 1], k=5, bc_type=([(1, 0.0), (2, 0.0)], [(1, 0.0), (2, 0.0)]))
+        self.spline_z = make_interp_spline(t, self.rotvecs[:, 2], k=5, bc_type=([(1, 0.0), (2, 0.0)], [(1, 0.0), (2, 0.0)]))
+
 
     def __call__(self, t_single):
         t_array = np.array([t_single])
         quaternions_fine = self.evaluate(t_array)
         return quaternions_fine[0]
-    
-    def update_t(self, new_t):
-        self.spline_x, self.t_x = make_interp_spline_with_constraints(new_t, self.rotvecs[:, 0], k=5, bc_type=([(1, 0.0), (2, 0.0)], [(1, 0.0), (2, 0.0)]), v_max=self.v_max, a_max=self.a_max)
-        self.spline_y, self.t_y = make_interp_spline_with_constraints(new_t, self.rotvecs[:, 1], k=5, bc_type=([(1, 0.0), (2, 0.0)], [(1, 0.0), (2, 0.0)]), v_max=self.v_max, a_max=self.a_max)
-        self.spline_z, self.t_z = make_interp_spline_with_constraints(new_t, self.rotvecs[:, 2], k=5, bc_type=([(1, 0.0), (2, 0.0)], [(1, 0.0), (2, 0.0)]), v_max=self.v_max, a_max=self.a_max)
 
     def evaluate(self, t_fine):
         rotvecs_fine = np.vstack((
@@ -145,25 +96,11 @@ class RotationSpline:
         angular_acc_z = self.spline_z(t_fine, 2)
         return np.vstack((angular_acc_x, angular_acc_y, angular_acc_z)).T
     
-# Fit splines to theta_x theta_y theta_z as a function of t
-quaternion_spline = RotationSpline(np.linspace(0, 1, len(x)), Rotation.from_euler("xyz", orientations, degrees=True).as_quat(), v_max=1, a_max=0.1)
+# orientation_spline = RotationSpline(
+#     t, Rotation.from_euler("xyz", orientations, degrees=True)
+# )
 
-new_xs.extend([quaternion_spline.t_x, quaternion_spline.t_y, quaternion_spline.t_z])
-
-final_x = [0.0] # Create final time interval such that each individual interval is max of corresponding intervals for each spline
-for i in range(len(new_xs[0]) - 1):
-    final_x.append(final_x[i] + max(new_x[i+1] - new_x[i] for new_x in new_xs))
-
-# Final update to splines with final_x
-splines = [
-    make_interp_spline_with_constraints(
-        final_x, var, k=5, bc_type=([(1, 0.0), (2, 0.0)], [(1, 0.0), (2, 0.0)]), v_max=1, a_max=1
-    )[0] for var in dim_vars
-]
-quaternion_spline.update_t(final_x)
-
-# Define a finer grid of t values for evaluation
-t_fine = np.linspace(0, final_x[-1], 100)
+quaternion_spline = RotationSpline(t, Rotation.from_euler("xyz", orientations, degrees=True).as_quat())
 
 # For angular velocities and accelerations:
 angular_velocities = quaternion_spline.angular_velocity(t_fine)
@@ -248,6 +185,7 @@ plt.tight_layout()
 plt.show()
 
 plt.savefig("plot.png")
+
 
 # Setup the figure and 3D axis
 fig = plt.figure()


### PR DESCRIPTION
This PR contributes certain features to the path generation features. Given a set of points (each with x, y, z positions and pitch, roll, yaw angles), we can now

- Enable the rotation splines to be continuous over 5 derivatives (by interpolating over rot_vecs)
- Determine time intervals between points in order to satisfy maximum spline velocity and acceleration bounds