### PR TITLE
Add PathVisualizer Plugin to Sim Stack

### DIFF
--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -84,4 +84,5 @@
     ],
     "python.defaultInterpreterPath": "/home/ros/env/bin/python",
     "autoDocstring.docstringFormat": "numpy",
+    "cmake.sourceDirectory": "/workspaces/RoboSub/src/simulation/simulation/custom_gz_plugins",
 }

--- a/build.sh
+++ b/build.sh
@@ -7,4 +7,9 @@ colcon build \
         --merge-install \
         --symlink-install \
         --cmake-args "-DCMAKE_BUILD_TYPE=$BUILD_TYPE" "-DCMAKE_EXPORT_COMPILE_COMMANDS=On" \
-        -Wall -Wextra -Wpedantic
+        -Wall -Wextra -Wpedantic \
+        --paths src/simulation/simulation/custom_gz_plugins \
+        --base-paths .
+
+
+

--- a/sim.sh
+++ b/sim.sh
@@ -15,7 +15,8 @@ trap cleanup SIGINT
 export GZ_PARTITION=127.0.0.1:ros
 export DISPLAY=:0
 export GZ_SIM_RESOURCE_PATH=`pwd`/src/simulation/simulation/models:$GZ_SIM_RESOURCE_PATH
-export GZ_SIM_SYSTEM_PLUGIN_PATH=`pwd`/src/simulation/simulation/models/CartPole/plugins:$GZ_SIM_SYSTEM_PLUGIN_PATH 
+export GZ_SIM_SYSTEM_PLUGIN_PATH=`pwd`/build/custom_gz_plugins:$GZ_SIM_SYSTEM_PLUGIN_PATH
+export GZ_GUI_PLUGIN_PATH=`pwd`/build/custom_gz_plugins:$GZ_GUI_PLUGIN_PATH
 
 # Start commands in the background
 gz sim src/simulation/simulation/models/world.urdf &

--- a/src/launch/simulation.py
+++ b/src/launch/simulation.py
@@ -26,5 +26,11 @@ def generate_launch_description():
                 parameters=[global_params],
                 arguments=["--ros-args", "--log-level", "warn"],
             ),
+            Node(
+                package="simulation",
+                executable="path_bridge",
+                parameters=[global_params],
+                arguments=["--ros-args", "--log-level", "info"],
+            ),
         ]
     )

--- a/src/simulation/package.xml
+++ b/src/simulation/package.xml
@@ -11,6 +11,7 @@
   <exec_depend>rclpy</exec_depend>
   <exec_depend>std_msgs</exec_depend>
   <exec_depend>geometry_msgs</exec_depend>
+  <depend>gz-msgs10</depend>
   <exec_depend>nav_msgs</exec_depend>
 
   <test_depend>ament_copyright</test_depend>

--- a/src/simulation/package.xml
+++ b/src/simulation/package.xml
@@ -7,6 +7,7 @@
   <maintainer email="scotthickmann21@gmail.com">ros</maintainer>
   <license>TODO: License declaration</license>
 
+  <build_depend>ament_cmake</build_depend>
   <exec_depend>rclpy</exec_depend>
   <exec_depend>std_msgs</exec_depend>
   <exec_depend>geometry_msgs</exec_depend>

--- a/src/simulation/setup.py
+++ b/src/simulation/setup.py
@@ -1,4 +1,5 @@
 from setuptools import find_packages, setup
+import os
 
 package_name = "simulation"
 
@@ -22,6 +23,7 @@ setup(
             "thrusters = simulation.nodes.thrusters:main",
             "sensors = simulation.nodes.sensors:main",
             "dvl_bridge = simulation.nodes.dvl_bridge:main",
+            "path_bridge = simulation.nodes.path_bridge:main",
         ],
     },
 )

--- a/src/simulation/simulation.md
+++ b/src/simulation/simulation.md
@@ -1,39 +1,69 @@
-# [Module Name]
+# Simulation Module
 
 **Authors and Maintainers**: [List maintainers and contact info]  
 
 ---
 
 ## Purpose  
-[Briefly explain the purpose of this module and its role in the overall system.]
+The Simulation Module is designed to simulate RoboSub in a Gazebo environment. It integrates various sensors and actuators to mimic real-world operations, providing a platform for testing and development of control and navigation algorithms.
 
 ---
 
 ## Nodes  
-- **[Node Name 1]**: [Describe the node's functionality.]  
-- **[Node Name 2]**: [Describe the node's functionality.]
-- **ETC.**
+- **PathBridgeNode**: Bridges ROS 2 path messages to Gazebo custom messages for path visualization.
+- **DVLBridgeNode**: Converts Gazebo Doppler Velocity Log (DVL) messages to ROS 2 messages for velocity tracking.
+- **Sensors**: Converts sensor messages from Gazebo into a unified format for state estimation and control.
+- **Thrusters**: Converts individual thruster commands into Gazebo messages to control the AUV's thrusters.
 
 ---
 
 ## Communication  
-- **Inputs**: [What messages or topics this module subscribes to.]
-- **Outputs**: [What messages or topics this module publishes.]
-- **Interconnections**: [How this module communicates with other modules/packages.]
+- **Inputs**: 
+  - `/generated_path` (ROS 2): Subscribed by `PathBridgeNode` to receive path data.
+  - `/dvl` (Gazebo): Subscribed by `DVLBridgeNode` to receive DVL data.
+  - `gz/imu`, `gz/depth`, `gz/pose` (Gazebo): Subscribed by `Sensors` node for IMU, depth, and pose data.
+  - `thrusts` (ROS 2): Subscribed by `Thrusters` node for thruster commands.
+
+- **Outputs**: 
+  - `/generated_path` (Gazebo): Published by `PathBridgeNode` for path visualization.
+  - `/gz/dvl` (ROS 2): Published by `DVLBridgeNode` for DVL data.
+  - `imu`, `depth`, `odometry` (ROS 2): Published by `Sensors` node for processed sensor data.
+  - `gz/thruster_X` (Gazebo): Published by `Thrusters` node for each thruster control.
+
+- **Interconnections**: 
+  - The `PathVisualizer` plugin in Gazebo uses the `/generated_path` topic to visualize the path.
+  - The `DVLBridgeNode` and `Sensors` node facilitate data exchange between Gazebo and ROS 2.
 
 ---
 
 ## Development Notes  
-- [List any important implementation notes, standards, or practices.]
-- [Highlight cross-development considerations, dependencies, or constraints.]
+- The `PathVisualizer` plugin is a custom Gazebo GUI plugin that visualizes paths using cones to represent waypoints and orientations.
+- The AUV model is defined in `model.urdf` and includes sensors like IMU, altimeter, and DVL, as well as thrusters for movement.
+- The simulation environment is configured in `world.urdf`, which includes plugins for physics, sensors, and visualization.
 
 ---
 
 ## Testing  
-- [Outline testing strategies for this module.]
-- [Specify any integration tests with other modules.]
+To test the `PathVisualizer` and other components, follow these steps in separate terminals:
+
+1. Run the simulation script:
+   ```bash
+   ./sim.sh
+   ```
+
+2. Launch the simulation environment:
+   ```bash
+   ros2 launch src/launch/simulation.py
+   ```
+
+3. Launch the planning module:
+   ```bash
+   ros2 launch src/launch/planning.py
+   ```
+
+These steps will set up the necessary environment to test the `PathVisualizer` functionality and other simulation components.
 
 ---
 
 ## References  
-[List any relevant documentation, papers, or resources.]
+- [List any relevant documentation, papers, or resources.]

--- a/src/simulation/simulation/custom_gz_plugins/CMakeLists.txt
+++ b/src/simulation/simulation/custom_gz_plugins/CMakeLists.txt
@@ -7,10 +7,10 @@ endif()
 project(custom_gz_plugins)
 
 find_package(gz-rendering8 REQUIRED)
-
+find_package(Protobuf REQUIRED)
 find_package(gz-cmake3 REQUIRED)
 find_package(gz-msgs10 REQUIRED)
-find_package(gz-transport14 REQUIRED)
+find_package(gz-transport13 REQUIRED)
 
 # Define a variable 'GZ_MSGS_VER' holding the version number
 set(GZ_MSGS_VER ${gz-msgs10_VERSION_MAJOR})
@@ -20,20 +20,12 @@ set(MSGS_PROTOS
    ${CMAKE_CURRENT_SOURCE_DIR}/proto/gz/custom_msgs/GeneratedPath.proto
 )
 
-# Call 'gz_msgs_generate_messages()' to process the .proto file
 gz_msgs_generate_messages(
-  # The cmake target to be generated for libraries/executables to link
-  TARGET msgs
-  # The protobuf package to generate (Typically based on the path)
-  PROTO_PACKAGE "gz.custom_msgs"
-  # The path to the base directory of the proto files
-  # All import paths should be relative to this (eg gz/custom_msgs/vector3d.proto)
-  MSGS_PATH ${CMAKE_CURRENT_SOURCE_DIR}/proto
-  # List of proto files to process
-  MSGS_PROTOS ${MSGS_PROTOS}
-  # Depenency on gz-msgs
-  DEPENDENCIES gz-msgs${GZ_MSGS_VER}::gz-msgs${GZ_MSGS_VER}
-
+    TARGET msgs
+    PROTO_PACKAGE gz.custom_msgs
+    MSGS_PATH ${CMAKE_CURRENT_SOURCE_DIR}/proto
+    MSGS_PROTOS ${MSGS_PROTOS}
+    DEPENDENCIES gz-msgs${GZ_MSGS_VER}::gz-msgs${GZ_MSGS_VER}
 )
 
 include_directories(
@@ -54,7 +46,11 @@ target_link_libraries(PathVisualizer
   PRIVATE
     gz-gui8::gz-gui8
     gz-rendering8::gz-rendering8
-    gz-transport14::gz-transport14
+    gz-transport13::gz-transport13
+    gz-msgs10::gz-msgs10
+  PUBLIC
+    custom_gz_plugins-msgs
 )
 
 install(TARGETS PathVisualizer DESTINATION ${$GZ_SIM_SYSTEM_PLUGIN_PATH})
+

--- a/src/simulation/simulation/custom_gz_plugins/CMakeLists.txt
+++ b/src/simulation/simulation/custom_gz_plugins/CMakeLists.txt
@@ -1,0 +1,28 @@
+cmake_minimum_required(VERSION 3.22.1 FATAL_ERROR)
+
+if(POLICY CMP0100)
+  cmake_policy(SET CMP0100 NEW)
+endif()
+
+project(custom_gz_plugins)
+
+# Common to both plugins
+find_package(gz-rendering8 REQUIRED)
+
+set(CMAKE_AUTOMOC ON)
+
+find_package(gz-gui8 REQUIRED)
+
+QT5_ADD_RESOURCES(resources_RCC PathVisualizer.qrc)
+
+add_library(PathVisualizer SHARED
+  PathVisualizer.cc
+  ${resources_RCC}
+)
+target_link_libraries(PathVisualizer
+  PUBLIC
+    gz-gui8::gz-gui8
+    gz-rendering8::gz-rendering8
+)
+
+install(TARGETS PathVisualizer DESTINATION ${$GZ_SIM_SYSTEM_PLUGIN_PATH})

--- a/src/simulation/simulation/custom_gz_plugins/CMakeLists.txt
+++ b/src/simulation/simulation/custom_gz_plugins/CMakeLists.txt
@@ -10,7 +10,11 @@ find_package(gz-rendering8 REQUIRED)
 
 find_package(gz-cmake3 REQUIRED)
 find_package(gz-msgs10 REQUIRED)
+<<<<<<< HEAD
 find_package(gz-transport10 REQUIRED)
+=======
+find_package(gz-transport14 REQUIRED)
+>>>>>>> a66a39c (added gz-ros bridge for path topic + added subscription to PathVisuzlizer)
 
 # Define a variable 'GZ_MSGS_VER' holding the version number
 set(GZ_MSGS_VER ${gz-msgs10_VERSION_MAJOR})
@@ -54,8 +58,7 @@ target_link_libraries(PathVisualizer
   PRIVATE
     gz-gui8::gz-gui8
     gz-rendering8::gz-rendering8
-  PUBLIC
-    PathVisualizer-msgs
+    gz-transport14::gz-transport14
 )
 
 install(TARGETS PathVisualizer DESTINATION ${$GZ_SIM_SYSTEM_PLUGIN_PATH})

--- a/src/simulation/simulation/custom_gz_plugins/CMakeLists.txt
+++ b/src/simulation/simulation/custom_gz_plugins/CMakeLists.txt
@@ -10,11 +10,7 @@ find_package(gz-rendering8 REQUIRED)
 
 find_package(gz-cmake3 REQUIRED)
 find_package(gz-msgs10 REQUIRED)
-<<<<<<< HEAD
-find_package(gz-transport10 REQUIRED)
-=======
 find_package(gz-transport14 REQUIRED)
->>>>>>> a66a39c (added gz-ros bridge for path topic + added subscription to PathVisuzlizer)
 
 # Define a variable 'GZ_MSGS_VER' holding the version number
 set(GZ_MSGS_VER ${gz-msgs10_VERSION_MAJOR})

--- a/src/simulation/simulation/custom_gz_plugins/CMakeLists.txt
+++ b/src/simulation/simulation/custom_gz_plugins/CMakeLists.txt
@@ -6,8 +6,33 @@ endif()
 
 project(custom_gz_plugins)
 
-# Common to both plugins
 find_package(gz-rendering8 REQUIRED)
+
+find_package(gz-cmake3 REQUIRED)
+find_package(gz-msgs10 REQUIRED)
+
+# Define a variable 'GZ_MSGS_VER' holding the version number
+set(GZ_MSGS_VER ${gz-msgs10_VERSION_MAJOR})
+
+# Define a variable 'MSGS_PROTOS' listing the .proto files
+set(MSGS_PROTOS
+   ${CMAKE_CURRENT_SOURCE_DIR}/proto/gz/custom_msgs/GeneratedPath.proto
+)
+
+# Call 'gz_msgs_generate_messages()' to process the .proto file
+gz_msgs_generate_messages(
+  # The cmake target to be generated for libraries/executables to link
+  TARGET msgs
+  # The protobuf package to generate (Typically based on the path)
+  PROTO_PACKAGE "gz.custom_msgs"
+  # The path to the base directory of the proto files
+  # All import paths should be relative to this (eg gz/custom_msgs/vector3d.proto)
+  MSGS_PATH ${CMAKE_CURRENT_SOURCE_DIR}/proto
+  # List of proto files to process
+  MSGS_PROTOS ${MSGS_PROTOS}
+  # Depenency on gz-msgs
+  DEPENDENCIES gz-msgs${GZ_MSGS_VER}::gz-msgs${GZ_MSGS_VER}
+)
 
 set(CMAKE_AUTOMOC ON)
 
@@ -20,7 +45,7 @@ add_library(PathVisualizer SHARED
   ${resources_RCC}
 )
 target_link_libraries(PathVisualizer
-  PUBLIC
+  PRIVATE
     gz-gui8::gz-gui8
     gz-rendering8::gz-rendering8
 )

--- a/src/simulation/simulation/custom_gz_plugins/CMakeLists.txt
+++ b/src/simulation/simulation/custom_gz_plugins/CMakeLists.txt
@@ -10,6 +10,7 @@ find_package(gz-rendering8 REQUIRED)
 
 find_package(gz-cmake3 REQUIRED)
 find_package(gz-msgs10 REQUIRED)
+find_package(gz-transport10 REQUIRED)
 
 # Define a variable 'GZ_MSGS_VER' holding the version number
 set(GZ_MSGS_VER ${gz-msgs10_VERSION_MAJOR})
@@ -32,6 +33,11 @@ gz_msgs_generate_messages(
   MSGS_PROTOS ${MSGS_PROTOS}
   # Depenency on gz-msgs
   DEPENDENCIES gz-msgs${GZ_MSGS_VER}::gz-msgs${GZ_MSGS_VER}
+
+)
+
+include_directories(
+  ${CMAKE_CURRENT_BINARY_DIR}/custom_gz_plugins-msgs_genmsg
 )
 
 set(CMAKE_AUTOMOC ON)
@@ -48,6 +54,8 @@ target_link_libraries(PathVisualizer
   PRIVATE
     gz-gui8::gz-gui8
     gz-rendering8::gz-rendering8
+  PUBLIC
+    PathVisualizer-msgs
 )
 
 install(TARGETS PathVisualizer DESTINATION ${$GZ_SIM_SYSTEM_PLUGIN_PATH})

--- a/src/simulation/simulation/custom_gz_plugins/PathVisualizer.cc
+++ b/src/simulation/simulation/custom_gz_plugins/PathVisualizer.cc
@@ -1,0 +1,157 @@
+/*
+ * Copyright (C) 2021 Open Source Robotics Foundation
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+*/
+
+#include <gz/gui/Application.hh>
+//! [includeGuiEvents]
+#include <gz/gui/GuiEvents.hh>
+//! [includeGuiEvents]
+#include <gz/gui/MainWindow.hh>
+#include <gz/math/Rand.hh>
+#include <gz/plugin/Register.hh>
+#include <gz/rendering/RenderEngine.hh>
+#include <gz/rendering/RenderingIface.hh>
+#include <gz/rendering/Scene.hh>
+
+#include "PathVisualizer.hh"
+
+/////////////////////////////////////////////////
+void PathVisualizer::LoadConfig(const tinyxml2::XMLElement * /*_pluginElem*/)
+{
+  // This is necessary to receive the Render event on eventFilter
+//! [connectToGuiEvent]
+  gz::gui::App()->findChild<
+      gz::gui::MainWindow *>()->installEventFilter(this);
+//! [connectToGuiEvent]
+}
+
+/////////////////////////////////////////////////
+void PathVisualizer::TogglePath()
+{
+  this->dirty = true;
+  this->showCube = !this->showCube;  // Toggle cube visibility
+}
+
+/////////////////////////////////////////////////
+//! [eventFilter]
+bool PathVisualizer::eventFilter(QObject *_obj, QEvent *_event)
+{
+  if (_event->type() == gz::gui::events::Render::kType)
+  {
+    // This event is called in the render thread, so it's safe to make
+    // rendering calls here
+    this->PerformRenderingOperations();
+  }
+
+  // Standard event processing
+  return QObject::eventFilter(_obj, _event);
+}
+//! [eventFilter]
+
+/////////////////////////////////////////////////
+//! [performRenderingOperations]
+void PathVisualizer::PerformRenderingOperations()
+{
+  if (!this->dirty)
+  {
+    return;
+  }
+
+  if (nullptr == this->scene)
+  {
+    this->FindScene();
+  }
+
+  if (nullptr == this->scene)
+    return;
+
+  // Remove existing cube if any
+  if (this->cubeVisual)
+  {
+    this->scene->RootVisual()->RemoveChild(this->cubeVisual);
+    this->cubeVisual.reset();
+  }
+
+  // Create and add a new cube if showCube is true
+  if (this->showCube)
+  {
+    this->cubeVisual = this->scene->CreateVisual("cube_visual");
+    auto cubeMesh = this->scene->CreateBox();
+    this->cubeVisual->AddGeometry(cubeMesh);
+    this->cubeVisual->SetLocalPosition(5.0, 5.0, 1.0);  // Arbitrary position
+    this->scene->RootVisual()->AddChild(this->cubeVisual);
+  }
+
+  this->dirty = false;
+}
+//! [performRenderingOperations]
+
+/////////////////////////////////////////////////
+void PathVisualizer::FindScene()
+{
+  auto loadedEngNames = gz::rendering::loadedEngines();
+  if (loadedEngNames.empty())
+  {
+    gzdbg << "No rendering engine is loaded yet" << std::endl;
+    return;
+  }
+
+  // assume there is only one engine loaded
+  auto engineName = loadedEngNames[0];
+  if (loadedEngNames.size() > 1)
+  {
+    gzdbg << "More than one engine is available. "
+      << "Using engine [" << engineName << "]" << std::endl;
+  }
+  auto engine = gz::rendering::engine(engineName);
+  if (!engine)
+  {
+    gzerr << "Internal error: failed to load engine [" << engineName
+      << "]. Grid plugin won't work." << std::endl;
+    return;
+  }
+
+  if (engine->SceneCount() == 0)
+  {
+    gzdbg << "No scene has been created yet" << std::endl;
+    return;
+  }
+
+  // Get first scene
+  auto scenePtr = engine->SceneByIndex(0);
+  if (nullptr == scenePtr)
+  {
+    gzerr << "Internal error: scene is null." << std::endl;
+    return;
+  }
+
+  if (engine->SceneCount() > 1)
+  {
+    gzdbg << "More than one scene is available. "
+      << "Using scene [" << scene->Name() << "]" << std::endl;
+  }
+
+  if (!scenePtr->IsInitialized() || nullptr == scenePtr->RootVisual())
+  {
+    return;
+  }
+
+  this->scene = scenePtr;
+}
+
+// Register this plugin
+GZ_ADD_PLUGIN(PathVisualizer,
+                    gz::gui::Plugin);

--- a/src/simulation/simulation/custom_gz_plugins/PathVisualizer.hh
+++ b/src/simulation/simulation/custom_gz_plugins/PathVisualizer.hh
@@ -64,51 +64,9 @@ class PathVisualizer : public gz::gui::Plugin
   private: gz::rendering::VisualPtr pathVisual{nullptr};
 
   /// \brief Subscriber for the path topic.
-  private: gazebo::transport::SubscriberPtr sub;
+  private: gz::transport::SubscriberPtr sub;
 
   /// \brief Stored path data from latest message
-  private: PoseTwistStampedPath pathData;
-
-  /// \brief Typedef for the path data
-  public: struct PoseTwistStampedPath {
-    
-  };
-
-  public: struct PoseTwistStamped {
-    Header header;
-    PoseStamped pose;
-    TwistStamped twist;
-  };
-
-  public: struct Header {
-    uint32 seq;
-    std::time timestamp;
-    std::string frame_id;
-  };
-
-  public: struct PoseStamped {
-    Header header;
-    Pose pose;
-  };  
-
-  public: struct TwistStamped {
-    Header header;
-    Twist twist;
-  };
-
-  public: struct Pose {
-    double x;
-    double y;
-    double z;
-  };
-
-  public: struct Twist {
-    double x;
-    double y;
-    double z;
-  };
-
-
-};
+  private: gz::custom_msgs::GeneratedPath pathData;
 
 #endif

--- a/src/simulation/simulation/custom_gz_plugins/PathVisualizer.hh
+++ b/src/simulation/simulation/custom_gz_plugins/PathVisualizer.hh
@@ -37,7 +37,7 @@ class PathVisualizer : public gz::gui::Plugin
   public slots: void TogglePath();
 
   /// \brief Callback for path update messages.
-  public slots: void PathUpdateCallback(const msgs::PoseTwistPath &_msg);
+  public slots: void PathUpdateCallback(const gz::custom_msgs::GeneratedPath &_msg);
 
   /// \brief Callback for all installed event filters.
   /// \param[in] _obj Object that received the event

--- a/src/simulation/simulation/custom_gz_plugins/PathVisualizer.hh
+++ b/src/simulation/simulation/custom_gz_plugins/PathVisualizer.hh
@@ -4,9 +4,10 @@
 #include <gz/gui/qt.h>
 #include <gz/gui/Plugin.hh>
 #include <gz/rendering/Scene.hh>
-#include <gz/msgs.hh>
 #include <gz/transport.hh>
 #include <gz/custom_msgs/GeneratedPath.pb.h>
+#include <mutex>
+#include <vector>
 
 /// \brief Example of a GUI plugin that uses Gazebo Rendering.
 /// This plugin works with Gazebo GUI's MinimalScene or any plugin providing
@@ -36,6 +37,10 @@ class PathVisualizer : public gz::gui::Plugin
   /// render engine singleton.
   private: void FindScene();
 
+  /// \brief Destructor to clean up markers.
+  public:
+    ~PathVisualizer();
+
   /// \brief Marks when a new change has been requested.
   private: bool dirty{false};
 
@@ -45,15 +50,17 @@ class PathVisualizer : public gz::gui::Plugin
   /// \brief Flag to toggle path visibility.
   private: bool showPath{false};
 
-  /// \brief Pointer to the path visual.
-  private: gz::rendering::VisualPtr pathVisual{nullptr};
-
   /// \brief Subscriber for the path topic.
   private: gz::transport::Node node;
 
-  /// \brief Stored path data from latest message
+  /// \brief Stored path data from latest message (the actual protobuf message)
   private: gz::custom_msgs::GeneratedPath pathData;
 
+  /// \brief Mutex to protect path data
+  private: std::mutex pathMutex;
+
+  /// \brief Store individual marker visuals
+  private: std::vector<gz::rendering::VisualPtr> pathMarkers;
 };
 
 #endif

--- a/src/simulation/simulation/custom_gz_plugins/PathVisualizer.hh
+++ b/src/simulation/simulation/custom_gz_plugins/PathVisualizer.hh
@@ -21,6 +21,7 @@
 #include <gz/gui/qt.h>
 #include <gz/gui/Plugin.hh>
 #include <gz/rendering/Scene.hh>
+#include <gz/msgs.hh>
 
 /// \brief Example of a GUI plugin that uses Gazebo Rendering.
 /// This plugin works with Gazebo GUI's MinimalScene or any plugin providing
@@ -34,6 +35,9 @@ class PathVisualizer : public gz::gui::Plugin
 
   /// \brief Callback when user clicks button.
   public slots: void TogglePath();
+
+  /// \brief Callback for path update messages.
+  public slots: void PathUpdateCallback(const msgs::PoseTwistPath &_msg);
 
   /// \brief Callback for all installed event filters.
   /// \param[in] _obj Object that received the event
@@ -53,11 +57,58 @@ class PathVisualizer : public gz::gui::Plugin
   /// \brief Pointer to the rendering scene.
   private: gz::rendering::ScenePtr scene{nullptr};
 
-  /// \brief Flag to toggle cube visibility.
-  private: bool showCube{false};
+  /// \brief Flag to toggle path visibility.
+  private: bool showPath{false};
 
-  /// \brief Pointer to the cube visual.
-  private: gz::rendering::VisualPtr cubeVisual{nullptr};
+  /// \brief Pointer to the path visual.
+  private: gz::rendering::VisualPtr pathVisual{nullptr};
+
+  /// \brief Subscriber for the path topic.
+  private: gazebo::transport::SubscriberPtr sub;
+
+  /// \brief Stored path data from latest message
+  private: PoseTwistStampedPath pathData;
+
+  /// \brief Typedef for the path data
+  public: struct PoseTwistStampedPath {
+    
+  };
+
+  public: struct PoseTwistStamped {
+    Header header;
+    PoseStamped pose;
+    TwistStamped twist;
+  };
+
+  public: struct Header {
+    uint32 seq;
+    std::time timestamp;
+    std::string frame_id;
+  };
+
+  public: struct PoseStamped {
+    Header header;
+    Pose pose;
+  };  
+
+  public: struct TwistStamped {
+    Header header;
+    Twist twist;
+  };
+
+  public: struct Pose {
+    double x;
+    double y;
+    double z;
+  };
+
+  public: struct Twist {
+    double x;
+    double y;
+    double z;
+  };
+
+
 };
 
 #endif

--- a/src/simulation/simulation/custom_gz_plugins/PathVisualizer.hh
+++ b/src/simulation/simulation/custom_gz_plugins/PathVisualizer.hh
@@ -22,6 +22,7 @@
 #include <gz/gui/Plugin.hh>
 #include <gz/rendering/Scene.hh>
 #include <gz/msgs.hh>
+#include <gz/transport.hh>
 
 /// \brief Example of a GUI plugin that uses Gazebo Rendering.
 /// This plugin works with Gazebo GUI's MinimalScene or any plugin providing

--- a/src/simulation/simulation/custom_gz_plugins/PathVisualizer.hh
+++ b/src/simulation/simulation/custom_gz_plugins/PathVisualizer.hh
@@ -1,20 +1,3 @@
-/*
- * Copyright (C) 2021 Open Source Robotics Foundation
- *
- * Licensed under the Apache License, Version 2.0 (the "License");
- * you may not use this file except in compliance with the License.
- * You may obtain a copy of the License at
- *
- *     http://www.apache.org/licenses/LICENSE-2.0
- *
- * Unless required by applicable law or agreed to in writing, software
- * distributed under the License is distributed on an "AS IS" BASIS,
- * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
- * See the License for the specific language governing permissions and
- * limitations under the License.
- *
-*/
-
 #ifndef PATH_VISUALIZER_HH_
 #define PATH_VISUALIZER_HH_
 
@@ -23,6 +6,7 @@
 #include <gz/rendering/Scene.hh>
 #include <gz/msgs.hh>
 #include <gz/transport.hh>
+#include <gz/custom_msgs/GeneratedPath.pb.h>
 
 /// \brief Example of a GUI plugin that uses Gazebo Rendering.
 /// This plugin works with Gazebo GUI's MinimalScene or any plugin providing
@@ -65,9 +49,11 @@ class PathVisualizer : public gz::gui::Plugin
   private: gz::rendering::VisualPtr pathVisual{nullptr};
 
   /// \brief Subscriber for the path topic.
-  private: gz::transport::SubscriberPtr sub;
+  private: gz::transport::Node node;
 
   /// \brief Stored path data from latest message
   private: gz::custom_msgs::GeneratedPath pathData;
+
+};
 
 #endif

--- a/src/simulation/simulation/custom_gz_plugins/PathVisualizer.hh
+++ b/src/simulation/simulation/custom_gz_plugins/PathVisualizer.hh
@@ -1,0 +1,63 @@
+/*
+ * Copyright (C) 2021 Open Source Robotics Foundation
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+*/
+
+#ifndef PATH_VISUALIZER_HH_
+#define PATH_VISUALIZER_HH_
+
+#include <gz/gui/qt.h>
+#include <gz/gui/Plugin.hh>
+#include <gz/rendering/Scene.hh>
+
+/// \brief Example of a GUI plugin that uses Gazebo Rendering.
+/// This plugin works with Gazebo GUI's MinimalScene or any plugin providing
+/// similar functionality.
+class PathVisualizer : public gz::gui::Plugin
+{
+  Q_OBJECT
+
+  ///\brief Called once at startup.
+  public: void LoadConfig(const tinyxml2::XMLElement *) override;
+
+  /// \brief Callback when user clicks button.
+  public slots: void TogglePath();
+
+  /// \brief Callback for all installed event filters.
+  /// \param[in] _obj Object that received the event
+  /// \param[in] _event Event
+  private: bool eventFilter(QObject *_obj, QEvent *_event) override;
+
+  /// \brief All rendering operations must happen within this call
+  private: void PerformRenderingOperations();
+
+  /// \brief Encapsulates the logic to find the rendering scene through the
+  /// render engine singleton.
+  private: void FindScene();
+
+  /// \brief Marks when a new change has been requested.
+  private: bool dirty{false};
+
+  /// \brief Pointer to the rendering scene.
+  private: gz::rendering::ScenePtr scene{nullptr};
+
+  /// \brief Flag to toggle cube visibility.
+  private: bool showCube{false};
+
+  /// \brief Pointer to the cube visual.
+  private: gz::rendering::VisualPtr cubeVisual{nullptr};
+};
+
+#endif

--- a/src/simulation/simulation/custom_gz_plugins/PathVisualizer.qml
+++ b/src/simulation/simulation/custom_gz_plugins/PathVisualizer.qml
@@ -1,0 +1,18 @@
+import QtQuick 2.9
+import QtQuick.Controls 2.2
+import QtQuick.Layouts 1.3
+
+Rectangle {
+  color: "transparent"
+  anchors.fill: parent
+  Layout.minimumWidth: 250
+  Layout.minimumHeight: 100
+  Button {
+    text: qsTr("Show Path!")
+    onClicked: {
+      PathVisualizer.TogglePath();
+    }
+    anchors.horizontalCenter: parent.horizontalCenter
+    anchors.verticalCenter: parent.verticalCenter
+  }
+}

--- a/src/simulation/simulation/custom_gz_plugins/PathVisualizer.qml
+++ b/src/simulation/simulation/custom_gz_plugins/PathVisualizer.qml
@@ -15,4 +15,10 @@ Rectangle {
     anchors.horizontalCenter: parent.horizontalCenter
     anchors.verticalCenter: parent.verticalCenter
   }
+  Text {
+    text: qsTr("Number of Points: " + PathVisualizer.pathData.poses_size())
+    anchors.horizontalCenter: parent.horizontalCenter
+    anchors.top: parent.top
+    anchors.topMargin: 30
+  }
 }

--- a/src/simulation/simulation/custom_gz_plugins/PathVisualizer.qrc
+++ b/src/simulation/simulation/custom_gz_plugins/PathVisualizer.qrc
@@ -1,0 +1,5 @@
+<!DOCTYPE RCC><RCC version="1.0">
+<qresource prefix="PathVisualizer/">
+  <file>PathVisualizer.qml</file>
+</qresource>
+</RCC>

--- a/src/simulation/simulation/custom_gz_plugins/package.xml
+++ b/src/simulation/simulation/custom_gz_plugins/package.xml
@@ -11,7 +11,7 @@
     <depend>gz-gui8</depend>
     <depend>gz-plugin2</depend>
     <depend>gz-rendering8</depend>
-    <depend>gz-transport15</depend>
+    <depend>gz-transport14</depend>
     <depend>std_msgs</depend>
     <depend>geometry_msgs</depend>
     <buildtool_depend>cmake</buildtool_depend>

--- a/src/simulation/simulation/custom_gz_plugins/package.xml
+++ b/src/simulation/simulation/custom_gz_plugins/package.xml
@@ -1,0 +1,29 @@
+<?xml version="1.0"?>
+<?xml-model href="http://download.ros.org/schema/package_format3.xsd" schematypens="http://www.w3.org/2001/XMLSchema"?>
+<package format="3">
+    <name>custom_gz_plugins</name>
+    <version>0.0.0</version>
+    <description>This package builds the custom plugins for Gazebo.</description>
+    <maintainer email="scotthickmann21@gmail.com">ros</maintainer>
+    <license>TODO: License declaration</license>
+
+    <depend>gz-cmake3</depend>
+    <depend>gz-common5</depend>
+    <depend>gz-gui8</depend>
+    <depend>gz-plugin2</depend>
+    <depend>gz-rendering8</depend>
+    <buildtool_depend>cmake</buildtool_depend>
+    <exec_depend>rclpy</exec_depend>
+    <exec_depend>std_msgs</exec_depend>
+
+    <test_depend>ament_copyright</test_depend>
+    <test_depend>ament_black</test_depend>
+    <test_depend>ament_pep257</test_depend>
+    <test_depend>python3-pytest</test_depend>
+
+    <export>
+        <build_type>cmake</build_type>
+
+    </export>
+
+</package>

--- a/src/simulation/simulation/custom_gz_plugins/package.xml
+++ b/src/simulation/simulation/custom_gz_plugins/package.xml
@@ -7,15 +7,23 @@
     <maintainer email="scotthickmann21@gmail.com">ros</maintainer>
     <license>TODO: License declaration</license>
 
-    <depend>gz-cmake3</depend>
     <depend>gz-common5</depend>
     <depend>gz-gui8</depend>
     <depend>gz-plugin2</depend>
     <depend>gz-rendering8</depend>
+    <depend>gz-transport15</depend>
     <depend>std_msgs</depend>
     <depend>geometry_msgs</depend>
     <buildtool_depend>cmake</buildtool_depend>
     <exec_depend>rclpy</exec_depend>
+
+    <build_depend>gz-cmake3</build_depend>
+    <depend>gz-math8</depend>
+    <depend>gz-tools2</depend>
+    <depend>protobuf-dev</depend>
+    <depend>python3-protobuf</depend>
+    <depend>python3</depend>
+    <depend>tinyxml2</depend>
 
     <test_depend>ament_copyright</test_depend>
     <test_depend>ament_black</test_depend>
@@ -24,7 +32,6 @@
 
     <export>
         <build_type>cmake</build_type>
-
     </export>
 
 </package>

--- a/src/simulation/simulation/custom_gz_plugins/package.xml
+++ b/src/simulation/simulation/custom_gz_plugins/package.xml
@@ -12,9 +12,12 @@
     <depend>gz-gui8</depend>
     <depend>gz-plugin2</depend>
     <depend>gz-rendering8</depend>
+    <depend>std_msgs</depend>
+    <depend>geometry_msgs</depend>
     <buildtool_depend>cmake</buildtool_depend>
     <exec_depend>rclpy</exec_depend>
     <exec_depend>std_msgs</exec_depend>
+    <exec_depend>geometry_msgs</exec_depend>
 
     <test_depend>ament_copyright</test_depend>
     <test_depend>ament_black</test_depend>

--- a/src/simulation/simulation/custom_gz_plugins/package.xml
+++ b/src/simulation/simulation/custom_gz_plugins/package.xml
@@ -11,7 +11,7 @@
     <depend>gz-gui8</depend>
     <depend>gz-plugin2</depend>
     <depend>gz-rendering8</depend>
-    <depend>gz-transport14</depend>
+    <depend>gz-transport13</depend>
     <depend>std_msgs</depend>
     <depend>geometry_msgs</depend>
     <buildtool_depend>cmake</buildtool_depend>
@@ -20,7 +20,7 @@
     <build_depend>gz-cmake3</build_depend>
     <depend>gz-math8</depend>
     <depend>gz-tools2</depend>
-    <depend>protobuf-dev</depend>
+    <depend>gz-msgs10</depend>
     <depend>python3-protobuf</depend>
     <depend>python3</depend>
     <depend>tinyxml2</depend>

--- a/src/simulation/simulation/custom_gz_plugins/package.xml
+++ b/src/simulation/simulation/custom_gz_plugins/package.xml
@@ -16,8 +16,6 @@
     <depend>geometry_msgs</depend>
     <buildtool_depend>cmake</buildtool_depend>
     <exec_depend>rclpy</exec_depend>
-    <exec_depend>std_msgs</exec_depend>
-    <exec_depend>geometry_msgs</exec_depend>
 
     <test_depend>ament_copyright</test_depend>
     <test_depend>ament_black</test_depend>

--- a/src/simulation/simulation/custom_gz_plugins/proto/gz/custom_msgs/GeneratedPath.proto
+++ b/src/simulation/simulation/custom_gz_plugins/proto/gz/custom_msgs/GeneratedPath.proto
@@ -1,9 +1,10 @@
 syntax = "proto3";
+package gz.custom_msgs;
 
-import "gz/msgs10/path_pb2.proto";
-import "gz/msgs10/twist_pb2.proto";
+import "gz/msgs/pose.proto";
+import "gz/msgs/twist.proto";
 
 message GeneratedPath {
-    repeated gz.msgs.Path paths = 1;
+    repeated gz.msgs.Pose poses = 1;
     repeated gz.msgs.Twist twists = 2;
 }

--- a/src/simulation/simulation/custom_gz_plugins/proto/gz/custom_msgs/GeneratedPath.proto
+++ b/src/simulation/simulation/custom_gz_plugins/proto/gz/custom_msgs/GeneratedPath.proto
@@ -1,0 +1,9 @@
+syntax = "proto3";
+
+import "gz/msgs10/path_pb2.proto";
+import "gz/msgs10/twist_pb2.proto";
+
+message GeneratedPath {
+    repeated gz.msgs.Path paths = 1;
+    repeated gz.msgs.Twist twists = 2;
+}

--- a/src/simulation/simulation/models/world.urdf
+++ b/src/simulation/simulation/models/world.urdf
@@ -23,6 +23,85 @@
       <uniform_fluid_density>1000</uniform_fluid_density>
     </plugin>
 
+    <gui fullscreen="0">
+      <!-- 3D scene -->
+      <plugin filename="GzScene3D" name="3D View">
+        <gz-gui>
+          <title>3D View</title>
+          <property type="bool" key="showTitleBar">false</property>
+          <property type="string" key="state">docked</property>
+        </gz-gui>
+
+        <engine>ogre2</engine>
+        <scene>scene</scene>
+        <ambient_light>0.4 0.4 0.4</ambient_light>
+        <background_color>0.8 0.8 0.8</background_color>
+        <camera_pose>-6 0 6 0 0.5 0</camera_pose>
+      </plugin>
+
+      <!-- World control -->
+      <plugin filename="WorldControl" name="World control">
+        <gz-gui>
+          <title>World control</title>
+          <property type="bool" key="showTitleBar">false</property>
+          <property type="bool" key="resizable">false</property>
+          <property type="double" key="height">72</property>
+          <property type="double" key="width">290</property>
+          <property type="double" key="z">1</property>
+
+          <property type="string" key="state">floating</property>
+          <anchors target="3D View">
+            <line own="left" target="left"/>
+            <line own="bottom" target="bottom"/>
+          </anchors>
+        </gz-gui>
+
+        <play_pause>true</play_pause>
+        <step>true</step>
+        <start_paused>true</start_paused>
+        <service>/world/world_demo/control</service>
+        <stats_topic>/world/world_demo/stats</stats_topic>
+      </plugin>
+
+      <!-- World statistics -->
+      <plugin filename="WorldStats" name="World stats">
+        <gz-gui>
+          <title>World stats</title>
+          <property type="bool" key="showTitleBar">false</property>
+          <property type="bool" key="resizable">false</property>
+          <property type="double" key="height">110</property>
+          <property type="double" key="width">290</property>
+          <property type="double" key="z">1</property>
+
+          <property type="string" key="state">floating</property>
+          <anchors target="3D View">
+            <line own="right" target="right"/>
+            <line own="bottom" target="bottom"/>
+          </anchors>
+        </gz-gui>
+
+        <sim_time>true</sim_time>
+        <real_time>true</real_time>
+        <real_time_factor>true</real_time_factor>
+        <iterations>true</iterations>
+      </plugin>
+
+      <!-- Entity tree -->
+      <plugin filename="EntityTree" name="Entity tree">
+        <gz-gui>
+          <property type="string" key="state">docked</property>
+        </gz-gui>
+      </plugin>
+
+      <!-- Path Visualizer Plugin -->
+      <plugin filename="PathVisualizer" name="Path Visualizer">
+        <gz-gui>
+          <title>Path Visualizer</title>
+          <property key="state" type="string">docked</property>
+        </gz-gui>
+      </plugin>
+    </gui>
+
     <plugin filename="gz-sim-imu-system" name="gz::sim::systems::Imu">
     </plugin>
     <plugin filename="gz-sim-dvl-system" name="gz::sim::systems::DopplerVelocityLogSystem">

--- a/src/simulation/simulation/nodes/path_bridge.py
+++ b/src/simulation/simulation/nodes/path_bridge.py
@@ -1,0 +1,85 @@
+import rclpy
+from rclpy.node import Node
+from msgs.msg import GeneratedPath
+from gz.transport13 import Node as GzNode
+from gz.custom_msgs.GeneratedPath import GeneratedPath as GzPath
+from gz.msgs10.pose_pb2 import Pose as GzPose
+from gz.msgs10.twist_pb2 import Twist as GzTwist
+from gz.msgs10.vector3d_pb2 import Vector3d
+from gz.msgs10.quaternion_pb2 import Quaternion
+
+class PathBridgeNode(Node):
+    def __init__(self):
+        super().__init__("path_bridge")
+        # Subscribe to ROS path topic
+        self.subscription = self.create_subscription(
+            GeneratedPath,
+            "/path",  # Adjust topic name as needed
+            self.path_callback,
+            10
+        )
+        
+        # Create Gazebo node and publisher
+        self.gz_node = GzNode()
+        self.gz_publisher = self.gz_node.advertise(GzPath, "/path")
+
+    def path_callback(self, msg: GeneratedPath):
+        self.get_logger().info("Received Path message")
+
+        # Create Gazebo Path message
+        gz_msg = GzPath()
+        
+        # Convert each PoseStamped and TwistStamped to Gazebo format
+        for pose in msg.poses:
+            gz_pose = GzPose()
+            
+            # Set position
+            position = Vector3d()
+            position.x = pose.pose.position.x
+            position.y = pose.pose.position.y
+            position.z = pose.pose.position.z
+            gz_pose.position.CopyFrom(position)
+            
+            # Set orientation
+            orientation = Quaternion()
+            orientation.x = pose.pose.orientation.x
+            orientation.y = pose.pose.orientation.y
+            orientation.z = pose.pose.orientation.z
+            orientation.w = pose.pose.orientation.w
+            gz_pose.orientation.CopyFrom(orientation)
+            
+            gz_msg.poses.append(gz_pose)
+
+        for twist in msg.twists:
+            gz_twist = GzTwist()
+            
+            # Set linear velocity
+            linear = Vector3d()
+            linear.x = twist.twist.linear.x
+            linear.y = twist.twist.linear.y
+            linear.z = twist.twist.linear.z
+            gz_twist.linear.CopyFrom(linear)
+            
+            # Set angular velocity
+            angular = Vector3d()
+            angular.x = twist.twist.angular.x
+            angular.y = twist.twist.angular.y
+            angular.z = twist.twist.angular.z
+            gz_twist.angular.CopyFrom(angular)
+            
+            gz_msg.twists.append(gz_twist)
+
+        # Publish the Gazebo message
+        self.gz_publisher.publish(gz_msg)
+
+
+def main(args=None):
+    rclpy.init(args=args)
+    node = PathBridgeNode()
+    rclpy.spin(node)
+    node.destroy_node()
+    rclpy.shutdown()
+
+
+if __name__ == "__main__":
+    main()

--- a/src/simulation/simulation/nodes/path_bridge.py
+++ b/src/simulation/simulation/nodes/path_bridge.py
@@ -8,38 +8,38 @@ from gz.msgs10.twist_pb2 import Twist as GzTwist
 from gz.msgs10.vector3d_pb2 import Vector3d
 from gz.msgs10.quaternion_pb2 import Quaternion
 
+
 class PathBridgeNode(Node):
     def __init__(self):
         super().__init__("path_bridge")
         # Subscribe to ROS path topic
         self.subscription = self.create_subscription(
             GeneratedPath,
-            "/path",  # Adjust topic name as needed
+            "/generated_path",  # Adjust topic name as needed
             self.path_callback,
-            10
+            10,
         )
-        
+
         # Create Gazebo node and publisher
         self.gz_node = GzNode()
-        self.gz_publisher = self.gz_node.advertise(GzPath, "/path")
+        self.gz_publisher = self.gz_node.advertise(GzPath, "/generated_path")
 
     def path_callback(self, msg: GeneratedPath):
         self.get_logger().info("Received Path message")
 
         # Create Gazebo Path message
         gz_msg = GzPath()
-        
+
         # Convert each PoseStamped and TwistStamped to Gazebo format
         for pose in msg.poses:
             gz_pose = GzPose()
-            
+
             # Set position
             position = Vector3d()
             position.x = pose.pose.position.x
             position.y = pose.pose.position.y
             position.z = pose.pose.position.z
             gz_pose.position.CopyFrom(position)
-            
             # Set orientation
             orientation = Quaternion()
             orientation.x = pose.pose.orientation.x
@@ -47,26 +47,22 @@ class PathBridgeNode(Node):
             orientation.z = pose.pose.orientation.z
             orientation.w = pose.pose.orientation.w
             gz_pose.orientation.CopyFrom(orientation)
-            
             gz_msg.poses.append(gz_pose)
 
         for twist in msg.twists:
             gz_twist = GzTwist()
-            
             # Set linear velocity
             linear = Vector3d()
             linear.x = twist.twist.linear.x
             linear.y = twist.twist.linear.y
             linear.z = twist.twist.linear.z
             gz_twist.linear.CopyFrom(linear)
-            
             # Set angular velocity
             angular = Vector3d()
             angular.x = twist.twist.angular.x
             angular.y = twist.twist.angular.y
             angular.z = twist.twist.angular.z
             gz_twist.angular.CopyFrom(angular)
-            
             gz_msg.twists.append(gz_twist)
 
         # Publish the Gazebo message

--- a/src/simulation/simulation/nodes/path_bridge.py
+++ b/src/simulation/simulation/nodes/path_bridge.py
@@ -1,20 +1,29 @@
+import os
+import sys
+
+# Add the correct lib/python path for custom msgs
+sys.path.append(
+    "/workspaces/RoboSub/build/custom_gz_plugins/custom_gz_plugins-msgs_genmsg/python"
+)
+
 import rclpy
 from rclpy.node import Node
-from msgs.msg import GeneratedPath
-from gz.transport13 import Node as GzNode
-from gz.custom_msgs.GeneratedPath import GeneratedPath as GzPath
-from gz.msgs10.pose_pb2 import Pose as GzPose
-from gz.msgs10.twist_pb2 import Twist as GzTwist
+from msgs.msg import GeneratedPath as ROSGeneratedPath
 from gz.msgs10.vector3d_pb2 import Vector3d
 from gz.msgs10.quaternion_pb2 import Quaternion
+from gz.msgs10.twist_pb2 import Twist
+from gz.msgs10.pose_pb2 import Pose
+from gz.transport13 import Node as GzNode
+from gz.custom_msgs.GeneratedPath_pb2 import GeneratedPath as GZGeneratedPath
 
 
 class PathBridgeNode(Node):
     def __init__(self):
+        print(sys.path)
         super().__init__("path_bridge")
         # Subscribe to ROS path topic
         self.subscription = self.create_subscription(
-            GeneratedPath,
+            ROSGeneratedPath,
             "/generated_path",  # Adjust topic name as needed
             self.path_callback,
             10,
@@ -22,47 +31,42 @@ class PathBridgeNode(Node):
 
         # Create Gazebo node and publisher
         self.gz_node = GzNode()
-        self.gz_publisher = self.gz_node.advertise(GzPath, "/generated_path")
+        self.gz_publisher = self.gz_node.advertise(
+            "/generated_path",
+            GZGeneratedPath,
+        )
 
-    def path_callback(self, msg: GeneratedPath):
-        self.get_logger().info("Received Path message")
+    def path_callback(self, msg: ROSGeneratedPath):
+        self.get_logger().info("Received Path message: Here it is:")
+        self.get_logger().info(f"{msg}")
 
         # Create Gazebo Path message
-        gz_msg = GzPath()
+        gz_msg = GZGeneratedPath()
 
         # Convert each PoseStamped and TwistStamped to Gazebo format
         for pose in msg.poses:
-            gz_pose = GzPose()
-
+            gz_pose = Pose()
             # Set position
-            position = Vector3d()
-            position.x = pose.pose.position.x
-            position.y = pose.pose.position.y
-            position.z = pose.pose.position.z
-            gz_pose.position.CopyFrom(position)
+            gz_pose.position.x = pose.pose.position.x
+            gz_pose.position.y = pose.pose.position.y
+            gz_pose.position.z = pose.pose.position.z
             # Set orientation
-            orientation = Quaternion()
-            orientation.x = pose.pose.orientation.x
-            orientation.y = pose.pose.orientation.y
-            orientation.z = pose.pose.orientation.z
-            orientation.w = pose.pose.orientation.w
-            gz_pose.orientation.CopyFrom(orientation)
+            gz_pose.orientation.x = pose.pose.orientation.x
+            gz_pose.orientation.y = pose.pose.orientation.y
+            gz_pose.orientation.z = pose.pose.orientation.z
+            gz_pose.orientation.w = pose.pose.orientation.w
             gz_msg.poses.append(gz_pose)
 
         for twist in msg.twists:
-            gz_twist = GzTwist()
+            gz_twist = Twist()
             # Set linear velocity
-            linear = Vector3d()
-            linear.x = twist.twist.linear.x
-            linear.y = twist.twist.linear.y
-            linear.z = twist.twist.linear.z
-            gz_twist.linear.CopyFrom(linear)
+            gz_twist.linear.x = twist.linear.x
+            gz_twist.linear.y = twist.linear.y
+            gz_twist.linear.z = twist.linear.z
             # Set angular velocity
-            angular = Vector3d()
-            angular.x = twist.twist.angular.x
-            angular.y = twist.twist.angular.y
-            angular.z = twist.twist.angular.z
-            gz_twist.angular.CopyFrom(angular)
+            gz_twist.angular.x = twist.angular.x
+            gz_twist.angular.y = twist.angular.y
+            gz_twist.angular.z = twist.angular.z
             gz_msg.twists.append(gz_twist)
 
         # Publish the Gazebo message


### PR DESCRIPTION
This pull request introduces the PathVisualizer plugin to the simulation module, providing path visualization capabilities in Gazebo.

New Features:
- Implements a GUI plugin to visualize paths using cones, representing waypoints and orientations.
- Integrates with ROS 2 and Gazebo to display real-time path data.

Documentation:
- Updated simulation.md with instructions for testing the Sim and PathVisualizer, including setup and execution steps.

Testing:
- Follow the instructions in simulation.md to test the new PathVisualizer functionality.